### PR TITLE
Fix values > 32bit integers on 32bit systems (arm7 etc)

### DIFF
--- a/gmusic.go
+++ b/gmusic.go
@@ -1,5 +1,6 @@
 // Package gmusic provides methods to list and play music from Google
 // Play Music.
+
 package gmusic
 
 import (
@@ -143,10 +144,10 @@ type SettingsData struct {
 
 type Settings struct {
 	EntitlementInfo struct {
-		ExpirationMillis int  `json:"expirationMillis"`
-		IsCanceled       bool `json:"isCanceled"`
-		IsSubscription   bool `json:"isSubscription"`
-		IsTrial          bool `json:"isTrial"`
+		ExpirationMillis uint64 `json:"expirationMillis"`
+		IsCanceled       bool   `json:"isCanceled"`
+		IsSubscription   bool   `json:"isSubscription"`
+		IsTrial          bool   `json:"isTrial"`
 	} `json:"entitlementInfo"`
 	Lab []struct {
 		Description    string `json:"description"`
@@ -154,14 +155,14 @@ type Settings struct {
 		Enabled        bool   `json:"enabled"`
 		ExperimentName string `json:"experimentName"`
 	} `json:"lab"`
-	MaxUploadedTracks      int  `json:"maxUploadedTracks"`
-	SubscriptionNewsletter bool `json:"subscriptionNewsletter"`
+	MaxUploadedTracks      uint32 `json:"maxUploadedTracks"`
+	SubscriptionNewsletter bool   `json:"subscriptionNewsletter"`
 	UploadDevice           []struct {
-		DeviceType             int    `json:"deviceType"`
+		DeviceType             uint32 `json:"deviceType"`
 		ID                     string `json:"id"`
 		LastAccessedFormatted  string `json:"lastAccessedFormatted"`
-		LastAccessedTimeMillis int    `json:"lastAccessedTimeMillis"`
-		LastEventTimeMillis    int    `json:"lastEventTimeMillis"`
+		LastAccessedTimeMillis uint64 `json:"lastAccessedTimeMillis"`
+		LastEventTimeMillis    uint64 `json:"lastEventTimeMillis"`
 		Name                   string `json:"name"`
 	} `json:"uploadDevice"`
 }
@@ -311,7 +312,7 @@ type Track struct {
 	Title                 string   `json:"title"`
 	TrackNumber           uint32   `json:"trackNumber"`
 	TrackType             string   `json:"trackType"`
-	Year                  int      `json:"year"`
+	Year                  uint32   `json:"year"`
 }
 
 // GetStream returns a http.Response with a Body streamed as an MP3.


### PR DESCRIPTION
On 32bit systems (such as arm7) the millisecond expiration times are too big to be contained in a standard 32bit int.

For example the `expirationMillis` json response from the API has a value in milliseconds, for me this value was `1486114474581` - this is too big to be held within a 32bit integer (max `2147483647`) on a 32bit system.

This PR replaces the `int` struct types to be `uint64` so the application can run on 32bit systems.